### PR TITLE
Improves CMake build system project handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,12 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+# CMP0000: Call the cmake_minimum_required() command at the beginning of the top-level
+# CMakeLists.txt file even before calling the project() command.
+# The cmake_minimum_required(VERSION) command implicitly invokes the cmake_policy(VERSION)
+# command to specify that the current project code is written for the given range of CMake
+# versions.
+project(SDDMConfigEditor)
 
 include(GNUInstallDirs)
-
-project(SDDMConfigEditor)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)


### PR DESCRIPTION
Make failing the CMake required version a fatal error.
Make the project declaration next to the cmake_minimum_required(). It
avoids scope issues. GNUInstallDirs was not in the correct scope.