### PR TITLE
Port to Qt5 signal/slot syntax

### DIFF
--- a/cpp/controller.cpp
+++ b/cpp/controller.cpp
@@ -91,7 +91,8 @@ QString Controller::absolutePath(const QString& path, const QString& filename)
 QObject* Controller::spawnProcess(const QString& line)
 {
   QProcess* process = new QProcess();
-  process->start(line);
+  QStringList arguments;
+  process->start(line, arguments);
   return process;
 }
 

--- a/cpp/setting.cpp
+++ b/cpp/setting.cpp
@@ -1,15 +1,18 @@
 #include "setting.h"
+#include "controller.h"
+
 #include <QVariant>
 #include <QString>
 #include <QJsonValue>
 
+
 Setting::Setting(QObject* parent) : QObject(parent)
 {
   if(parent) {
-    QObject* controller = parent->property("controller").value<QObject*>();
+    Controller* controller = parent->property("controller").value<Controller*>();
     if(controller) {
-      QObject::connect(this, SIGNAL(valueChanged()), controller, SLOT(generate()));
-      QObject::connect(this, SIGNAL(valueChanged()), controller, SIGNAL(modelChanged()));
+      connect(this, &Setting::valueChanged, controller, &Controller::generate);
+      connect(this, &Setting::valueChanged, controller, &Controller::modelChanged);
     }
   }
 }


### PR DESCRIPTION
remove deprecated overloading QProcess::start